### PR TITLE
Add ICoCoMethodContext.AFTER_INITIALIZE to utils module.

### DIFF
--- a/src/icoco/utils.py
+++ b/src/icoco/utils.py
@@ -72,14 +72,19 @@ class ICoCoMethods:  # pylint: disable=too-few-public-methods
 class ICoCoMethodContext:  # pylint: disable=too-few-public-methods
     """Namespace to list all context restrictions for ICoCo methods."""
 
-    BEFORE_INITIALIZE = ["setDataFile", "setMPIComm", "initialize"]
-    """Methods which must be called BEFORE ``initialize``."""
+    ONLY_BEFORE_INITIALIZE = ["setDataFile", "setMPIComm", "initialize"]
+    """Methods which must be called only BEFORE ``initialize``."""
+
+    ONLY_AFTER_INITIALIZE = [name for name in ICoCoMethods.ALL
+                             if name not in ["setDataFile", "setMPIComm", "initialize",
+                                             "getMEDCouplingMajorVersion", "isMEDCoupling64Bits" ]]
+    """Methods which must be called only AFTER ``initialize``."""
 
     ONLY_INSIDE_TIME_STEP_DEFINED = ["solveTimeStep", "iterateTimeStep",
                                      "validateTimeStep", "abortTimeStep"]
-    """Methods which must be called inside TIME_STEP_DEFINED context."""
+    """Methods which must be called only inside TIME_STEP_DEFINED context."""
 
     ONLY_OUTSIDE_TIME_STEP_DEFINED = [  # "getStationaryMode", FIXME norme says it should be here
         "terminate", "computeTimeStep", "initTimeStep", "setStationaryMode",
         "isStationary", "resetTime", "save", "restore"]
-    """Methods which must be called outside TIME_STEP_DEFINED context."""
+    """Methods which must be called only outside TIME_STEP_DEFINED context."""


### PR DESCRIPTION
Qu'est-ce que tu en penses ? Juste pour éviter d'avoir une petite liste de noms de méthodes dans la vérification du contexte.

D'ailleurs ne serait-il par pertinent de renommer BEFORE_INITIALIZE en ONLY_BEFORE_INITIALIZE  et AFTER_INITIALIZE  en ONLY_AFTER_INITIALIZE  ? C'est plus juste et cohérent avec les autres éléments de ICoCoMethodContext.